### PR TITLE
feat(tools): Compact tool args so tool function defaults can be used

### DIFF
--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -188,7 +188,7 @@ tool_request_args <- function(request) {
     return(new_tool_result(request, error = e))
   }
 
-  convert_from_type(args, tool@arguments)
+  compact(convert_from_type(args, tool@arguments))
 }
 
 maybe_on_tool_request <- function(

--- a/R/content-tools.R
+++ b/R/content-tools.R
@@ -188,7 +188,8 @@ tool_request_args <- function(request) {
     return(new_tool_result(request, error = e))
   }
 
-  compact(convert_from_type(args, tool@arguments))
+  args <- convert_from_type(args, tool@arguments)
+  args[!map_lgl(args, is.null)]
 }
 
 maybe_on_tool_request <- function(

--- a/tests/testthat/test-chat-structured.R
+++ b/tests/testthat/test-chat-structured.R
@@ -127,7 +127,7 @@ test_that("can convert arrays of enums to factors", {
   )
 })
 
-test_that("can covert arrays of objects to data framnes", {
+test_that("can convert arrays of objects to data frames", {
   expect_equal(
     convert_from_type(
       list(list(x = 1, y = "x"), list(x = 3, y = "y")),
@@ -142,7 +142,7 @@ test_that("can covert arrays of objects to data framnes", {
   )
 })
 
-test_that("can recursive convert objets contents", {
+test_that("can recursively convert objects contents", {
   expect_equal(
     convert_from_type(
       list(x = 1, y = list(1, 2, 3)),

--- a/tests/testthat/test-content-tools.R
+++ b/tests/testthat/test-content-tools.R
@@ -228,14 +228,19 @@ test_that("invoke_tools() converts to R data structures", {
     y = type_array(items = type_string())
   )
 
-  res <- invoke_tool(
+  req <-
     ContentToolRequest(
       id = "x",
       name = "my_tool",
       arguments = list(x = list(1, 2), y = list()),
       tool = tool
     )
-  )
+
+  args <- tool_request_args(req)
+  expect_equal(args$x, c(1, 2))
+  expect_equal(args$y, character())
+
+  res <- invoke_tool(req)
   expect_equal(out$x, c(1, 2))
   expect_equal(out$y, character())
 })
@@ -249,16 +254,79 @@ test_that("invoke_tools_async() converts to R data structures", {
     y = type_array(items = type_string())
   )
 
-  res <- sync(invoke_tool_async(
+  req <-
     ContentToolRequest(
       id = "x",
       name = "my_tool",
       arguments = list(x = list(1, 2), y = list()),
       tool = tool
     )
-  ))
+
+  args <- tool_request_args(req)
+  expect_equal(args$x, c(1, 2))
+  expect_equal(args$y, character())
+
+  res <- sync(invoke_tool_async(req))
   expect_equal(out$x, c(1, 2))
   expect_equal(out$y, character())
+})
+
+test_that("invoke_tools() can invoke tools with args with default values", {
+  out <- NULL
+  tool <- tool(
+    function(x, y, z = "z") out <<- list(x = x, y = y, z = z),
+    "A tool",
+    x = type_array(items = type_number()),
+    y = type_array(items = type_string()),
+    z = type_array(items = type_string(), required = FALSE)
+  )
+
+  req <-
+    ContentToolRequest(
+      id = "x",
+      name = "my_tool",
+      arguments = list(x = list(1, 2), y = NULL, z = NULL),
+      tool = tool
+    )
+
+  args <- tool_request_args(req)
+  expect_equal(args$x, c(1, 2))
+  expect_equal(args$y, character()) # Required arg
+  expect_equal(args$z, NULL) # Optional arg
+
+  res <- invoke_tool(req)
+  expect_equal(out$x, c(1, 2))
+  expect_equal(out$y, character())
+  expect_equal(out$z, "z")
+})
+
+test_that("invoke_tools_async() can invoke tools with args with default values", {
+  out <- NULL
+  tool <- tool(
+    function(x, y, z = "z") out <<- list(x = x, y = y, z = z),
+    "A tool",
+    x = type_array(items = type_number()),
+    y = type_array(items = type_string()),
+    z = type_array(items = type_string(), required = FALSE)
+  )
+
+  req <-
+    ContentToolRequest(
+      id = "x",
+      name = "my_tool",
+      arguments = list(x = list(1, 2), y = NULL, z = NULL),
+      tool = tool
+    )
+
+  args <- tool_request_args(req)
+  expect_equal(args$x, c(1, 2))
+  expect_equal(args$y, character()) # Required arg
+  expect_equal(args$z, NULL) # Optional arg
+
+  res <- sync(invoke_tool_async(req))
+  expect_equal(out$x, c(1, 2))
+  expect_equal(out$y, character())
+  expect_equal(out$z, "z")
 })
 
 test_that("tool error warnings", {


### PR DESCRIPTION
Updates `tool_request_args()` to `compact()` the args, dropping `NULL` values. Without this, the model will include `{"arg": null}`, which is then passed to `arg`, even if it's not required (implying the tool function has a default value).