### PR TITLE
chore: Return full tool request call when `format(req, show="call")`

### DIFF
--- a/R/chat-tools.R
+++ b/R/chat-tools.R
@@ -300,10 +300,14 @@ maybe_echo_tool <- function(x, echo = "output") {
   }
 
   if (is_tool_request(x)) {
+    call_str <- format(x, show = "call")
+    if (length(call_str) > 1) {
+      call_str <- paste0(call_str[1], "...)")
+    }
     cli::cli_text(
       cli::col_blue(cli::symbol$circle),
       " [{cli::col_blue('tool call')}] ",
-      cli_escape(format(x, show = "call"))
+      cli_escape(call_str)
     )
     return(invisible(x))
   }

--- a/R/content.R
+++ b/R/content.R
@@ -214,13 +214,12 @@ method(format, ContentToolRequest) <- function(
   }
   call <- call2(x@name, !!!arguments)
   call_str <- deparse(call)
-  if (length(call_str) > 1) {
-    open <-
-      call_str <- paste0(call_str[1], "...)")
-  }
-
   if (show == "call") {
     return(call_str)
+  }
+
+  if (length(call_str) > 1) {
+    call_str <- paste0(call_str[1], "...)")
   }
 
   cli::format_inline("[{.strong tool request} ({x@id})]: {call_str}")


### PR DESCRIPTION
Small change to `method(format, ContentToolRequest)` to return the full call when `show = "call"`. Otherwise, when `show = "all"`, the call is truncated to the first line.

I'm using `format(req, show = "call")` in shinychat to get the tool call as code that the user can copy, paste and run directly if needed. It'd be helpful to avoid needing to replicate the `format()` logic, but for this to be effective, we want the full call.
