### PR TITLE
fix(interpolate_package): Check path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Config/testthat/parallel: true
 Config/testthat/start-first: chat, provider*
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate:
     'utils-S7.R'
     'types.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `models_ollama()` was fixed to correctly query model capabilities from remote Ollama servers (#746).
 
+* `chat_claude()` is no longer deprecated and is an alias for `chat_anthropic()`, reflecting Anthropic's recent rebranding of developer tools under the Claude name (#758).
+
 # ellmer 0.3.2
 
 * `chat()` is now compatible with most `chat_` functions (#699).

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -51,13 +51,6 @@ chat_bedrock <- function(...) {
 
 #' @rdname deprecated
 #' @export
-chat_claude <- function(...) {
-  lifecycle::deprecate_warn("0.2.0", "chat_claude()", "chat_anthropic()")
-  chat_anthropic(...)
-}
-
-#' @rdname deprecated
-#' @export
 chat_gemini <- function(...) {
   lifecycle::deprecate_warn("0.2.0", "chat_gemini()", "chat_google_gemini()")
   chat_google_gemini(...)

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -51,6 +51,7 @@ interpolate <- function(prompt, ..., .envir = parent.frame()) {
 #' @rdname interpolate
 #' @export
 interpolate_file <- function(path, ..., .envir = parent.frame()) {
+  check_string(path)
   string <- read_file(path)
   interpolate(string, ..., .envir = .envir)
 }
@@ -64,12 +65,22 @@ interpolate_package <- function(
   ...,
   .envir = parent.frame()
 ) {
+  check_string(path)
+
   path <- system.file("prompts", path, package = package)
+
+  if (!nzchar(path)) {
+    cli::cli_abort(c(
+      "{.pkg {package}} does not have {.val {path}} in its {.field prompts/} directory.",
+      "i" = 'Run {.run dir(system.file("prompts", package = "{package}"))} to see available prompts.'
+    ))
+  }
+
   interpolate_file(path, ..., .envir = .envir)
 }
 
 read_file <- function(path) {
-  file_contents <- readChar(path, file.size(path))
+  readChar(path, file.size(path))
 }
 
 # Prompt class -----------------------------------------------------------------

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -67,16 +67,16 @@ interpolate_package <- function(
 ) {
   check_string(path)
 
-  path <- system.file("prompts", path, package = package)
+  path_pkg <- system.file("prompts", path, package = package)
 
-  if (!nzchar(path)) {
+  if (!nzchar(path_pkg)) {
     cli::cli_abort(c(
       "{.pkg {package}} does not have {.val {path}} in its {.field prompts/} directory.",
       "i" = 'Run {.run dir(system.file("prompts", package = "{package}"))} to see available prompts.'
     ))
   }
 
-  interpolate_file(path, ..., .envir = .envir)
+  interpolate_file(path_pkg, ..., .envir = .envir)
 }
 
 read_file <- function(path) {

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -7,7 +7,7 @@
 #'
 #' * `interpolate()` works with a string.
 #' * `interpolate_file()` works with a file.
-#' * `interpolate_package()` works with a file in the `insts/prompt`
+#' * `interpolate_package()` works with a file in the `inst/prompts`
 #'   directory of a package.
 #'
 #' Compared to glue, dynamic values should be wrapped in `{{ }}`, making it
@@ -46,7 +46,8 @@ interpolate <- function(prompt, ..., .envir = parent.frame()) {
   ellmer_prompt(out)
 }
 
-#' @param path A path to a prompt file (often a `.md`).
+#' @param path A path to a prompt file (often a `.md`). In
+#'   `interpolate_package()`, this path is relative to `inst/prompts`.
 #' @rdname interpolate
 #' @export
 interpolate_file <- function(path, ..., .envir = parent.frame()) {

--- a/R/provider-anthropic.R
+++ b/R/provider-anthropic.R
@@ -69,6 +69,10 @@ chat_anthropic <- function(
   Chat$new(provider = provider, system_prompt = system_prompt, echo = echo)
 }
 
+#' @rdname chat_anthropic
+#' @export
+chat_claude <- chat_anthropic
+
 chat_anthropic_test <- function(
   ...,
   model = "claude-3-5-sonnet-latest",

--- a/R/provider-anthropic.R
+++ b/R/provider-anthropic.R
@@ -7,11 +7,11 @@ NULL
 #' Chat with an Anthropic Claude model
 #'
 #' @description
-#' [Anthropic](https://www.anthropic.com) provides a number of chat based
-#' models under the [Claude](https://www.anthropic.com/claude) moniker.
-#' Note that a Claude Pro membership does not give you the ability to call
-#' models via the API; instead, you will need to sign up (and pay for) a
-#' [developer account](https://console.anthropic.com/).
+#' [Anthropic](https://www.anthropic.com) provides a number of chat based models
+#' under the [Claude](https://claude.com/product/overview) moniker. Note that a
+#' Claude Pro membership does not give you the ability to call models via the
+#' API; instead, you will need to sign up (and pay for) a
+#' [developer account](https://platform.claude.com/).
 #'
 #' @inheritParams chat_openai
 #' @inherit chat_openai return

--- a/man/batch_chat.Rd
+++ b/man/batch_chat.Rd
@@ -95,7 +95,7 @@ errors in the most helpful way. Fortunately they don't seem to be common,
 but if you have ideas, please let me know!
 }
 \examples{
-\dontshow{if (has_credentials("openai")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (has_credentials("openai")) withAutoprint(\{ # examplesIf}
 chat <- chat_openai(model = "gpt-4.1-nano")
 
 # Chat ----------------------------------------------------------------------

--- a/man/chat_anthropic.Rd
+++ b/man/chat_anthropic.Rd
@@ -2,10 +2,24 @@
 % Please edit documentation in R/provider-anthropic.R
 \name{chat_anthropic}
 \alias{chat_anthropic}
+\alias{chat_claude}
 \alias{models_anthropic}
 \title{Chat with an Anthropic Claude model}
 \usage{
 chat_anthropic(
+  system_prompt = NULL,
+  params = NULL,
+  max_tokens = deprecated(),
+  model = NULL,
+  api_args = list(),
+  base_url = "https://api.anthropic.com/v1",
+  beta_headers = character(),
+  api_key = anthropic_key(),
+  api_headers = character(),
+  echo = NULL
+)
+
+chat_claude(
   system_prompt = NULL,
   params = NULL,
   max_tokens = deprecated(),

--- a/man/chat_anthropic.Rd
+++ b/man/chat_anthropic.Rd
@@ -66,11 +66,11 @@ Note this only affects the \code{chat()} method.}
 A \link{Chat} object.
 }
 \description{
-\href{https://www.anthropic.com}{Anthropic} provides a number of chat based
-models under the \href{https://www.anthropic.com/claude}{Claude} moniker.
-Note that a Claude Pro membership does not give you the ability to call
-models via the API; instead, you will need to sign up (and pay for) a
-\href{https://console.anthropic.com/}{developer account}.
+\href{https://www.anthropic.com}{Anthropic} provides a number of chat based models
+under the \href{https://claude.com/product/overview}{Claude} moniker. Note that a
+Claude Pro membership does not give you the ability to call models via the
+API; instead, you will need to sign up (and pay for) a
+\href{https://platform.claude.com/}{developer account}.
 }
 \examples{
 \dontshow{ellmer:::vcr_example_start("chat_anthropic")}

--- a/man/chat_azure_openai.Rd
+++ b/man/chat_azure_openai.Rd
@@ -90,7 +90,7 @@ package.
 }
 \examples{
 \dontrun{
-chat <- chat_azure_openai(deployment_id = "gpt-4o-mini")
+chat <- chat_azure_openai(model = "gpt-4o-mini")
 chat$chat("Tell me three jokes about statisticians")
 }
 }

--- a/man/chat_snowflake.Rd
+++ b/man/chat_snowflake.Rd
@@ -79,7 +79,7 @@ than a general-purpose model.
 }
 }
 \examples{
-\dontshow{if (has_credentials("snowflake")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (has_credentials("snowflake")) withAutoprint(\{ # examplesIf}
 chat <- chat_snowflake()
 chat$chat("Tell me a joke in the form of a SQL query.")
 \dontshow{\}) # examplesIf}

--- a/man/deprecated.Rd
+++ b/man/deprecated.Rd
@@ -5,7 +5,6 @@
 \alias{chat_cortex}
 \alias{chat_azure}
 \alias{chat_bedrock}
-\alias{chat_claude}
 \alias{chat_gemini}
 \title{Deprecated functions}
 \usage{
@@ -14,8 +13,6 @@ chat_cortex(...)
 chat_azure(...)
 
 chat_bedrock(...)
-
-chat_claude(...)
 
 chat_gemini(...)
 }

--- a/man/ellmer-package.Rd
+++ b/man/ellmer-package.Rd
@@ -32,7 +32,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC (03wc8by49) [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }

--- a/man/interpolate.Rd
+++ b/man/interpolate.Rd
@@ -23,7 +23,8 @@ code.}
 wrapping in another function. See \code{vignette("wrappers", package = "glue")}
 for more details.}
 
-\item{path}{A path to a prompt file (often a \code{.md}).}
+\item{path}{A path to a prompt file (often a \code{.md}). In
+\code{interpolate_package()}, this path is relative to \code{inst/prompts}.}
 
 \item{package}{Package name.}
 }
@@ -37,7 +38,7 @@ dynamic data into a static prompt:
 \itemize{
 \item \code{interpolate()} works with a string.
 \item \code{interpolate_file()} works with a file.
-\item \code{interpolate_package()} works with a file in the \code{insts/prompt}
+\item \code{interpolate_package()} works with a file in the \code{inst/prompts}
 directory of a package.
 }
 

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -17,13 +17,6 @@ test_that("chat_bedrock() is deprecated", {
   )
 })
 
-test_that("chat_claude() is deprecated", {
-  lifecycle::expect_deprecated(
-    chat_claude(api_key = "key"),
-    "chat_anthropic"
-  )
-})
-
 test_that("chat_gemini() is deprecated", {
   lifecycle::expect_deprecated(
     chat_gemini(api_key = "key"),


### PR DESCRIPTION
* Updates the `interpolate_package()` docs to correct `inst/prompts` path
* Adds a check that the package prompt path exists and throw with informative error if not.
* Adds checks that `path` is scalar in `interpolate_package()` and `interpolate_file()`.

## Before

Before this PR, `interpolate_package()` falis with an error about `invalid "nchars" argument` because `system.file()` returns `""` for a missing path and `file.size("")` returns `NA`.

``` r
library(ellmer)

interpolate_package("btw", "missing.md")
#> Warning in file(con, "rb"): file("") only supports open = "w+" and open =
#> "w+b": using the former
#> Warning in readChar(path, file.size(path)): text connection used with
#> readChar(), results may be incorrect
#> Error in readChar(path, file.size(path)): invalid 'nchars' argument
```

In Positron at least, you typically only see the `nchars` part, like this

```
Error in `readChar()`:
! invalid 'nchars' argument
```

which is confusing -- my first thought is usually that I've done something wrong with the template strings.

## After

``` r
pkgload::load_all()
#> ℹ Loading ellmer

interpolate_package("btw", "missing.md")
#> Error in `interpolate_package()`:
#> ! btw does not have "missing.md" in its prompts/ directory.
#> ℹ Run `dir(system.file("prompts", package = "btw"))` to see available prompts.
```
